### PR TITLE
Add Todoist-Clockify Chrome extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,52 @@
+async function getStored(key) {
+  return new Promise(resolve => chrome.storage.sync.get(key, data => resolve(data[key])));
+}
+
+async function fetchProjects() {
+  const apiKey = await getStored('apiKey');
+  const workspaceId = await getStored('workspaceId');
+  if (!apiKey || !workspaceId) return [];
+  const res = await fetch(`https://api.clockify.me/api/v1/workspaces/${workspaceId}/projects`, {
+    headers: { 'X-Api-Key': apiKey }
+  });
+  if (!res.ok) throw new Error('Failed to load projects');
+  return res.json();
+}
+
+async function logTime(description, duration, projectId) {
+  const apiKey = await getStored('apiKey');
+  const workspaceId = await getStored('workspaceId');
+  if (!apiKey || !workspaceId) throw new Error('Missing API key or workspace ID');
+  const start = new Date();
+  const end = new Date(start.getTime() + duration * 1000);
+  const res = await fetch(`https://api.clockify.me/api/v1/workspaces/${workspaceId}/time-entries`, {
+    method: 'POST',
+    headers: {
+      'X-Api-Key': apiKey,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      description,
+      projectId,
+      start: start.toISOString(),
+      end: end.toISOString()
+    })
+  });
+  if (!res.ok) throw new Error('Failed to create time entry');
+  return res.json();
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'getProjects') {
+    fetchProjects()
+      .then(projects => sendResponse({ projects }))
+      .catch(err => sendResponse({ error: err.message }));
+    return true;
+  }
+  if (msg.type === 'logTime') {
+    logTime(msg.description, msg.duration, msg.projectId)
+      .then(entry => sendResponse({ entry }))
+      .catch(err => sendResponse({ error: err.message }));
+    return true;
+  }
+});

--- a/content-script.js
+++ b/content-script.js
@@ -1,0 +1,94 @@
+let projects = [];
+
+chrome.runtime.sendMessage({ type: 'getProjects' }, response => {
+  if (response && response.projects) {
+    projects = response.projects;
+    buildProjectList();
+    observeTasks();
+  }
+});
+
+function buildProjectList() {
+  const dataList = document.createElement('datalist');
+  dataList.id = 'clockify-projects';
+  projects.forEach(p => {
+    const option = document.createElement('option');
+    option.value = p.name;
+    option.dataset.id = p.id;
+    dataList.appendChild(option);
+  });
+  document.body.appendChild(dataList);
+}
+
+function parseDuration(str) {
+  const match = str.trim().match(/(?:(\d+)h)?\s*(?:(\d+)m)?/i);
+  if (!match) return null;
+  const hours = parseInt(match[1] || '0', 10);
+  const minutes = parseInt(match[2] || '0', 10);
+  return hours * 3600 + minutes * 60;
+}
+
+function observeTasks() {
+  const addToTask = task => {
+    if (task.querySelector('.clockify-time-input')) return;
+    const timeInput = document.createElement('input');
+    timeInput.placeholder = 'Time (e.g., 30m)';
+    timeInput.className = 'clockify-time-input';
+
+    const projectInput = document.createElement('input');
+    projectInput.setAttribute('list', 'clockify-projects');
+    projectInput.placeholder = 'Clockify project';
+    projectInput.className = 'clockify-project-input';
+
+    const btn = document.createElement('button');
+    btn.textContent = 'Log';
+    btn.className = 'clockify-log-btn';
+
+    const getDescription = () => {
+      const clone = task.cloneNode(true);
+      clone.querySelector('.clockify-time-input')?.remove();
+      clone.querySelector('.clockify-project-input')?.remove();
+      clone.querySelector('.clockify-log-btn')?.remove();
+      return clone.textContent.trim();
+    };
+
+    btn.addEventListener('click', () => {
+      const projectName = projectInput.value;
+      const option = Array.from(document.querySelectorAll('#clockify-projects option')).find(o => o.value === projectName);
+      const projectId = option ? option.dataset.id : null;
+      const duration = parseDuration(timeInput.value);
+      const description = getDescription();
+      if (!projectId || !duration) return;
+      chrome.runtime.sendMessage(
+        { type: 'logTime', description, duration, projectId },
+        res => {
+          if (res && res.error) {
+            console.error(res.error);
+          } else {
+            timeInput.value = '';
+            projectInput.value = '';
+          }
+        }
+      );
+    });
+
+    task.appendChild(timeInput);
+    task.appendChild(projectInput);
+    task.appendChild(btn);
+  };
+
+  document.querySelectorAll('[data-task-id]').forEach(addToTask);
+
+  const observer = new MutationObserver(mutations => {
+    mutations.forEach(m => {
+      m.addedNodes.forEach(node => {
+        if (node.nodeType === Node.ELEMENT_NODE && node.matches('[data-task-id]')) {
+          addToTask(node);
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+          node.querySelectorAll('[data-task-id]').forEach(addToTask);
+        }
+      });
+    });
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 3,
+  "name": "Todoist Clockify Integration",
+  "version": "0.1.0",
+  "description": "Adds a Clockify time entry interface to Todoist tasks.",
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://api.clockify.me/*",
+    "https://todoist.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://todoist.com/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "options_page": "options.html",
+  "action": {
+    "default_title": "Todoist Clockify Integration"
+  }
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Todoist Clockify Options</title>
+</head>
+<body>
+  <label>
+    Clockify API Key:
+    <input id="apiKey" type="text">
+  </label>
+  <br>
+  <label>
+    Workspace ID:
+    <input id="workspaceId" type="text">
+  </label>
+  <br>
+  <button id="save">Save</button>
+  <span id="status"></span>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,19 @@
+function save() {
+  const apiKey = document.getElementById('apiKey').value;
+  const workspaceId = document.getElementById('workspaceId').value;
+  chrome.storage.sync.set({ apiKey, workspaceId }, () => {
+    const status = document.getElementById('status');
+    status.textContent = 'Saved!';
+    setTimeout(() => (status.textContent = ''), 2000);
+  });
+}
+
+function restore() {
+  chrome.storage.sync.get(['apiKey', 'workspaceId'], data => {
+    document.getElementById('apiKey').value = data.apiKey || '';
+    document.getElementById('workspaceId').value = data.workspaceId || '';
+  });
+}
+
+document.getElementById('save').addEventListener('click', save);
+document.addEventListener('DOMContentLoaded', restore);

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,17 @@
-This is a test of Codex.
+# Todoist Clockify Chrome Extension
+
+This repository contains a simple Chrome extension that injects Clockify time-entry fields into Todoist's web interface.
+
+## Features
+
+- Adds a duration field to each Todoist task that accepts plain language entries like `30m` or `1h`.
+- Provides a searchable project input backed by projects from your Clockify workspace.
+- Sends the captured time entry to Clockify when the **Log** button is pressed, using the Todoist task title as the entry description.
+
+## Setup
+
+1. Open `chrome://extensions` in Chrome.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and choose this folder.
+4. Open the extension's options page and enter your Clockify API key and workspace ID.
+5. Navigate to Todoist; each task will display Clockify controls.


### PR DESCRIPTION
## Summary
- set up Chrome extension manifest and service worker
- inject duration and project inputs into Todoist tasks and log entries to Clockify
- add options page for saving API credentials and updated documentation
- default Clockify entry description to the Todoist task title

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3396b22083228659d2b442eb31fa